### PR TITLE
部署到远端服务器上时，访问前端页面时仍然调用localhost的问题

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,9 +87,14 @@ services:
       args:
         - VITE_MCP_PORT=${MCP_PORT:-8082}
         - VITE_MANAGER_SERVER_PORT=${MANAGER_SERVER_PORT:-7072}
+        - VITE_MANAGER_SERVER_HOST=${MANAGER_SERVER_HOST:-}
+        - VITE_API_BASE_URL=${VITE_API_BASE_URL:-}
     pull_policy: never
     image: graphiti-mcp-pro-frontend
     container_name: graphiti-mcp-pro-frontend
+    environment:
+      # Caddy 运行时需要的环境变量
+      - VITE_MANAGER_SERVER_PORT=${MANAGER_SERVER_PORT:-7072}
     networks:
       - default
     ports:

--- a/manager/frontend/Caddyfile
+++ b/manager/frontend/Caddyfile
@@ -1,8 +1,24 @@
 # Caddyfile for serving the frontend in docker
 :80 {
   bind 0.0.0.0
-  root * /usr/share/frontend
-  encode
-  file_server
-  try_files {path} /index.html
+  
+  # API 代理 - 将 /api 请求转发到后端服务
+  handle /api/* {
+    # 直接转发到后端，保持 /api 前缀
+    # 使用环境变量 {$VITE_MANAGER_SERVER_PORT} 支持动态端口配置
+    reverse_proxy mcp-with-manager:{$VITE_MANAGER_SERVER_PORT} {
+      # 健康检查
+      health_uri /health
+      health_interval 30s
+      health_timeout 10s
+    }
+  }
+  
+  # 前端静态文件服务
+  handle {
+    root * /usr/share/frontend
+    encode gzip
+    file_server
+    try_files {path} /index.html
+  }
 }

--- a/manager/frontend/Dockerfile
+++ b/manager/frontend/Dockerfile
@@ -21,6 +21,8 @@ COPY . ./
 # Set build arguments from docker-compose args
 ARG VITE_MCP_PORT
 ARG VITE_MANAGER_SERVER_PORT
+ARG VITE_MANAGER_SERVER_HOST
+ARG VITE_API_BASE_URL
 
 # Build the application
 RUN pnpm run build

--- a/manager/frontend/src/api/alova/client.ts
+++ b/manager/frontend/src/api/alova/client.ts
@@ -1,8 +1,19 @@
 import { createAlovaInstance } from './base'
 
-const MANAGER_SERVER_PORT = import.meta.env.VITE_MANAGER_SERVER_PORT || '7072'
 // API base URL configuration
-const API_BASE_URL = `http://localhost:${MANAGER_SERVER_PORT}`
+// 使用代理方式：前端API路径已包含 /api，由 Caddy 代理转发到后端服务
+const getApiBaseUrl = () => {
+  // 如果有完整的 API 基础 URL 配置，直接使用（用于开发环境或特殊配置）
+  if (import.meta.env.VITE_API_BASE_URL) {
+    return import.meta.env.VITE_API_BASE_URL
+  }
+  
+  // 生产环境：使用空字符串，因为 API 路径已经包含 /api 前缀
+  // Caddy 会代理所有 /api/* 请求到后端服务
+  return ''
+}
+
+const API_BASE_URL = getApiBaseUrl()
 
 // Create alova instance
 export const alovaInstance = createAlovaInstance(API_BASE_URL)


### PR DESCRIPTION
localhost写死了, 修改了Caddy反向代理将请求转发到对应的后端服务 mcp-with-manager:{$VITE_MANAGER_SERVER_PORT}而不是本地的localhost